### PR TITLE
Stability fixes for creating separators or pillars 

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1749,11 +1749,11 @@ func parseSeparators(path string, first, second interface{}, arg *node) (map[str
 	}
 
 	separators, obj, e := fetchObjAttr(path, "separators")
-	var sepArray []interface{}
-	attr := obj["attributes"].(map[string]interface{})
-	if e != nil {
+	if e != nil || obj == nil {
 		return nil, e
 	}
+	var sepArray []interface{}
+	attr := obj["attributes"].(map[string]interface{})
 
 	if IsInfArr(separators) {
 		sepArray = separators.([]interface{})
@@ -1826,11 +1826,11 @@ func parsePillars(path string, first, second interface{}, arg *node) (map[string
 	}
 
 	pillars, obj, e := fetchObjAttr(path, "pillars")
-	var pillarArray []interface{}
-	attr := obj["attributes"].(map[string]interface{})
-	if e != nil {
+	if e != nil || obj == nil {
 		return nil, e
 	}
+	var pillarArray []interface{}
+	attr := obj["attributes"].(map[string]interface{})
 
 	if IsInfArr(pillars) {
 		pillarArray = pillars.([]interface{})


### PR DESCRIPTION
This fixes crashing when trying to add separators or pillars to non existing objects. For example: 
```
path/to/NonExistingRoom:separator=[5,5]@[5,5]@wireframe
path/to/NonExistingRoom:separator:pillar=[5,5]@[5,5]@-29
```