### PR TITLE
The 'template' attribute is now inserted regardless for Buildings

### DIFF
--- a/controllers/commandController.go
+++ b/controllers/commandController.go
@@ -1425,6 +1425,9 @@ func GetOCLIAtrributes(Path string, ent int, data map[string]interface{}) error 
 			} else {
 				attr["size"] = serialiseAttr2(attr, "size")
 			}
+
+			//Since template was not provided, set it empty
+			attr["template"] = ""
 		}
 
 		if attr["size"] == "" {


### PR DESCRIPTION
Enables all buildings created to have a 'template' attribute which can be empty if template was not provided or the name of a Building Template slug